### PR TITLE
Fix issue where all players predicting 0 prevents navigation to scoring round

### DIFF
--- a/templates/game_show.html
+++ b/templates/game_show.html
@@ -17,7 +17,7 @@
         </td>
       </tr>
     </table>
-  {% elif latest_game_round.total_tricks_predicted %}
+  {% elif latest_game_round.total_tricks_predicted is not none %}
     <table align="center" style="width: 25%" class="table table-borderless">
       <tr>
         <td align="center">


### PR DESCRIPTION
This PR fixes the issue where the game fails to navigate to the scoring round if all players predict 0. The condition in game_show.html has been updated to handle this scenario.